### PR TITLE
Update the notify naming and behavior

### DIFF
--- a/RZBluetooth/Profiles/CBPeripheral+RZBBattery.m
+++ b/RZBluetooth/Profiles/CBPeripheral+RZBBattery.m
@@ -27,25 +27,25 @@
 {
     NSParameterAssert(update);
     completion = completion ?: ^(NSError *e) {};
-    [self addObserverForCharacteristicUUID:[CBUUID rzb_UUIDForBatteryLevelCharacteristic]
-                               serviceUUID:[CBUUID rzb_UUIDForBatteryService]
-                                  onChange:^(CBCharacteristic *characteristic, NSError *error) {
-                                      uint8_t level;
-                                      [characteristic.value getBytes:&level length:sizeof(level)];
-                                      update(level, error);
-                                  } completion:^(CBCharacteristic *characteristic, NSError *error) {
-                                      completion(error);
-                                  }];
+    [self enableNotifyForCharacteristicUUID:[CBUUID rzb_UUIDForBatteryLevelCharacteristic]
+                                serviceUUID:[CBUUID rzb_UUIDForBatteryService]
+                                   onUpdate:^(CBCharacteristic *characteristic, NSError *error) {
+                                       uint8_t level;
+                                       [characteristic.value getBytes:&level length:sizeof(level)];
+                                       update(level, error);
+                                   } completion:^(CBCharacteristic *characteristic, NSError *error) {
+                                       completion(error);
+                                   }];
 }
 
 - (void)removeBatteryLevelObserver:(RZBErrorBlock)completion
 {
     completion = completion ?: ^(NSError *e) {};
-    [self removeObserverForCharacteristicUUID:[CBUUID rzb_UUIDForBatteryLevelCharacteristic]
-                                  serviceUUID:[CBUUID rzb_UUIDForBatteryService]
-                                   completion:^(CBCharacteristic *characteristic, NSError *error) {
-                                       completion(error);
-                                   }];
+    [self clearNotifyBlockForCharacteristicUUID:[CBUUID rzb_UUIDForBatteryLevelCharacteristic]
+                                    serviceUUID:[CBUUID rzb_UUIDForBatteryService]
+                                     completion:^(CBCharacteristic *characteristic, NSError *error) {
+                                         completion(error);
+                                     }];
 }
 
 @end

--- a/RZBluetooth/Profiles/CBPeripheral+RZBHeartRate.m
+++ b/RZBluetooth/Profiles/CBPeripheral+RZBHeartRate.m
@@ -33,9 +33,9 @@ typedef NS_ENUM(uint8_t, RZBHeartRateControl) {
 {
     NSParameterAssert(update);
     NSParameterAssert(completion);
-    [self addObserverForCharacteristicUUID:[CBUUID rzb_UUIDForHeartRateMeasurementCharacteristic]
+    [self enableNotifyForCharacteristicUUID:[CBUUID rzb_UUIDForHeartRateMeasurementCharacteristic]
                                serviceUUID:[CBUUID rzb_UUIDForHeartRateService]
-                                  onChange:^(CBCharacteristic *characteristic, NSError *error) {
+                                  onUpdate:^(CBCharacteristic *characteristic, NSError *error) {
                                       RZBHeartRateMeasurement *m = [[RZBHeartRateMeasurement alloc] initWithBluetoothData:characteristic.value];
                                       update(m, error);
                                   } completion:^(CBCharacteristic *characteristic, NSError *error) {
@@ -46,7 +46,7 @@ typedef NS_ENUM(uint8_t, RZBHeartRateControl) {
 - (void)removeHeartRateObserver:(RZBHeartRateCompletion)completion
 {
     NSParameterAssert(completion);
-    [self removeObserverForCharacteristicUUID:[CBUUID rzb_UUIDForHeartRateMeasurementCharacteristic]
+    [self clearNotifyBlockForCharacteristicUUID:[CBUUID rzb_UUIDForHeartRateMeasurementCharacteristic]
                                   serviceUUID:[CBUUID rzb_UUIDForHeartRateService]
                                    completion:^(CBCharacteristic *characteristic, NSError *error) {
                                        completion(error);

--- a/RZBluetooth/RZBCentralManager.m
+++ b/RZBluetooth/RZBCentralManager.m
@@ -286,8 +286,8 @@ static BOOL s_useMockCoreBluetooth = NO;
     for (RZBCommand *command in commands) {
         [self.dispatch completeCommand:command withObject:nil error:error];
     }
-    // Clear out any onUpdate: blocks
-    peripheral.notifyBlockByUUID.removeAllObjects
+    // Clear out any onUpdate blocks
+    [peripheral.notifyBlockByUUID removeAllObjects];
     [self triggerAutomaticConnectionForPeripheral:peripheral];
 }
 

--- a/RZBluetooth/RZBCentralManager.m
+++ b/RZBluetooth/RZBCentralManager.m
@@ -286,6 +286,8 @@ static BOOL s_useMockCoreBluetooth = NO;
     for (RZBCommand *command in commands) {
         [self.dispatch completeCommand:command withObject:nil error:error];
     }
+    // Clear out any onUpdate: blocks
+    peripheral.notifyBlockByUUID.removeAllObjects
     [self triggerAutomaticConnectionForPeripheral:peripheral];
 }
 

--- a/RZBluetooth/RZBPeripheral.h
+++ b/RZBluetooth/RZBPeripheral.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  * battery limitations.
  *
  * If you have more complex connection requirements, use the onConnection and onDisconnection behavior.
- * 
+ *
  * @note This bool is set to NO when cancelConnection is called.
  */
 @property (nonatomic) BOOL maintainConnection;
@@ -100,35 +100,36 @@ NS_ASSUME_NONNULL_BEGIN
                    serviceUUID:(CBUUID *)serviceUUID
                     completion:(RZBCharacteristicBlock)completion;
 /**
- * Add an observer to monitor a characteristic for changes in value. The onChange block will be
- * triggered every time the characteristic changes.
+ * Enable notification on the specified characteristic and call the completion block when the notify
+ * has been set on the device. The onUpdate block will be triggered when the characteristic value is
+ * updated by the peripheral for the entire life of the connection. When the connection is torn down,
+ * all of the change blocks will be invalidated, and the notify block should be registered when the
+ * connection occurs.
  *
- * @note if a value is already present for the characteristic, the onChange block will be triggered
- *       immediately. This will happen if the bluetooth service already has a cached value. If this
- *       behavior is not desired, call RZBShouldTriggerInitialValue(false)
+ * @note CoreBluetooth may already have a value for the characteristic when the notify block is
+ *       registered, but the onUpdate block will not be triggered with this value. If this value is
+ *       of interest, check the characteristic for a non-nil value object when the completion block fires.
  */
-- (void)addObserverForCharacteristicUUID:(CBUUID *)characteristicUUID
-                             serviceUUID:(CBUUID *)serviceUUID
-                                onChange:(RZBCharacteristicBlock)onChange
-                              completion:(RZBCharacteristicBlock __nullable)completion;
+- (void)enableNotifyForCharacteristicUUID:(CBUUID *)characteristicUUID
+                              serviceUUID:(CBUUID *)serviceUUID
+                                 onUpdate:(RZBCharacteristicBlock)onUpdate
+                               completion:(RZBCharacteristicBlock __nullable)completion;
 
 /**
- * Remove the observer monitoring the characteristic for changes in value. The onChange block
- * will be removed immediately apon invocation. The completion block will be triggered
- * once the peripheral has been notified that it no longer needs to send updates to this central.
+ * Set notify value to NO, and clear the notification block for the specified characteristic. The onUpdate
+ * block that was registered in enable notify will be removed immediately apon invocation. The completion 
+ * block will be triggered once the peripheral has been notified that it no longer needs to send updates to this central.
  */
-- (void)removeObserverForCharacteristicUUID:(CBUUID *)characteristicUUID
-                                serviceUUID:(CBUUID *)serviceUUID
-                                 completion:(RZBCharacteristicBlock __nullable)completion;
-
-
+- (void)clearNotifyBlockForCharacteristicUUID:(CBUUID *)characteristicUUID
+                                  serviceUUID:(CBUUID *)serviceUUID
+                                   completion:(RZBCharacteristicBlock __nullable)completion;
 
 /**
  * Write the data to a specific characteristic.
  *
  * @param data The data to write to the characteristic.
  *
- * @note If the length of data is greater than the MTU Length (Default is 20bytes),
+ * @note If the length of data is greater than the MTU Length (Default is 20 bytes),
  *       CoreBluetooth will perform a staged write, which can have throughput
  *       implications.
  */
@@ -140,7 +141,7 @@ characteristicUUID:(CBUUID *)characteristicUUID
  * Write the data to a specific characteristic and wait for a response from the
  * device. This is the same as the above command with a completion block.
  *
- * @note the completion block requires a notification from the device and may also
+ * @note The completion block requires a notification from the device and may also
  *       impact throughput. It shouldn't be used unless required.
  */
 - (void)writeData:(NSData *)data

--- a/RZBluetooth/RZBPeripheral.m
+++ b/RZBluetooth/RZBPeripheral.m
@@ -138,33 +138,28 @@
     [self.dispatch dispatchCommand:cmd];
 }
 
-- (void)addObserverForCharacteristicUUID:(CBUUID *)characteristicUUID
-                             serviceUUID:(CBUUID *)serviceUUID
-                                onChange:(RZBCharacteristicBlock)onChange
-                              completion:(RZBCharacteristicBlock)completion;
+- (void)enableNotifyForCharacteristicUUID:(CBUUID *)characteristicUUID
+                              serviceUUID:(CBUUID *)serviceUUID
+                                 onUpdate:(RZBCharacteristicBlock)onUpdate
+                               completion:(RZBCharacteristicBlock)completion
 {
-    NSParameterAssert(onChange);
+    NSParameterAssert(onUpdate);
     RZB_DEFAULT_BLOCK(completion);
     RZBUUIDPath *path = RZBUUIDP(self.identifier, serviceUUID, characteristicUUID);
     RZBNotifyCharacteristicCommand *cmd = [[RZBNotifyCharacteristicCommand alloc] initWithUUIDPath:path];
     cmd.notify = YES;
     [cmd addCallbackBlock:^(CBCharacteristic *characteristic, NSError *error) {
         if (characteristic != nil) {
-            [self setNotifyBlock:onChange forCharacteristicUUID:characteristic.UUID];
+            [self setNotifyBlock:onUpdate forCharacteristicUUID:characteristic.UUID];
         }
-        // REMOVE FOR NOW!!!
-        //        if (//RZBExtensionShouldTriggerInitialValue &&
-        //            characteristic.value && error == nil) {
-        //            onChange(characteristic, nil);
-        //        }
         completion(characteristic, error);
     }];
     [self.dispatch dispatchCommand:cmd];
 }
 
-- (void)removeObserverForCharacteristicUUID:(CBUUID *)characteristicUUID
-                                serviceUUID:(CBUUID *)serviceUUID
-                                 completion:(RZBCharacteristicBlock)completion;
+- (void)clearNotifyBlockForCharacteristicUUID:(CBUUID *)characteristicUUID
+                                  serviceUUID:(CBUUID *)serviceUUID
+                                   completion:(RZBCharacteristicBlock)completion
 {
     RZB_DEFAULT_BLOCK(completion);
     RZBUUIDPath *path = RZBUUIDP(self.identifier, serviceUUID, characteristicUUID);

--- a/RZBluetoothTests/PacketPeripheral.swift
+++ b/RZBluetoothTests/PacketPeripheral.swift
@@ -12,7 +12,7 @@ class PacketPeripheral: RZBPeripheral {
     var packets: [Packet] = []
 
     func setPacketObserver(newPacket: (Packet) -> Void) {
-        addObserverForCharacteristicUUID(PacketUUID.fromDevice, serviceUUID: PacketUUID.service, onChange: { characteristic, error in
+        enableNotifyForCharacteristicUUID(PacketUUID.fromDevice, serviceUUID: PacketUUID.service, onUpdate: { characteristic, error in
             if let characteristic = characteristic, data = characteristic.value {
                 newPacket(Packet.fromData(data))
             }

--- a/RZBluetoothTests/RZBCentralManagerCallbackTests.m
+++ b/RZBluetoothTests/RZBCentralManagerCallbackTests.m
@@ -157,9 +157,9 @@ static NSString *const RZBTestString = @"StringValue";
     __block BOOL completed = NO;
     [self.mockCentralManager fakeStateChange:CBCentralManagerStatePoweredOn];
 
-    [peripheral addObserverForCharacteristicUUID:self.class.cUUID
+    [peripheral enableNotifyForCharacteristicUUID:self.class.cUUID
                                      serviceUUID:self.class.sUUID
-                                        onChange:^(CBCharacteristic *c, NSError *error) {
+                                        onUpdate:^(CBCharacteristic *c, NSError *error) {
                                             [values addObject:[[NSString alloc] initWithData:c.value encoding:NSUTF8StringEncoding]];
                                         } completion:^(CBCharacteristic *c, NSError *error) {
                                             completed = YES;

--- a/RZMockBluetooth/Mock/RZBMockPeripheral.h
+++ b/RZMockBluetooth/Mock/RZBMockPeripheral.h
@@ -54,28 +54,6 @@
 
 @end
 
-@interface RZBMockPeripheral (Dynamic)
-- (void)rzb_readRSSI:(RZBRSSIBlock)completion;
-- (void)rzb_readCharacteristicUUID:(CBUUID *)characteristicUUID
-                       serviceUUID:(CBUUID *)serviceUUID
-                        completion:(RZBCharacteristicBlock)completion;
-- (void)rzb_addObserverForCharacteristicUUID:(CBUUID *)characteristicUUID
-                                 serviceUUID:(CBUUID *)serviceUUID
-                                    onChange:(RZBCharacteristicBlock)onChange
-                                  completion:(RZBCharacteristicBlock)completion;
-- (void)rzb_removeObserverForCharacteristicUUID:(CBUUID *)characteristicUUID
-                                    serviceUUID:(CBUUID *)serviceUUID
-                                     completion:(RZBCharacteristicBlock)completion;
-- (void)rzb_writeData:(NSData *)data
-   characteristicUUID:(CBUUID *)characteristicUUID
-          serviceUUID:(CBUUID *)serviceUUID;
-- (void)rzb_writeData:(NSData *)data
-   characteristicUUID:(CBUUID *)characteristicUUID
-          serviceUUID:(CBUUID *)serviceUUID
-           completion:(RZBCharacteristicBlock)completion;
-
-@end
-
 @protocol RZBMockPeripheralDelegate <NSObject>
 
 - (void)mockPeripheral:(RZBMockPeripheral *)peripheral discoverServices:(NSArray *)serviceUUIDs;


### PR DESCRIPTION
This stops using the name `observer` and documents the initial value rather than triggering onUpdate.