### PR TITLE
Trigger error on terminal states

### DIFF
--- a/RZBluetooth/RZBCentralManager.m
+++ b/RZBluetooth/RZBCentralManager.m
@@ -197,10 +197,8 @@ static BOOL s_useMockCoreBluetooth = NO;
         case CBCentralManagerStateResetting:
             [self.dispatch resetCommands];
             break;
-        case CBCentralManagerStatePoweredOn:
+        default:
             [self.dispatch dispatchPendingCommands];
-            break;
-        default: {}
     }
 }
 

--- a/RZBluetoothTests/RZBCentralManagerCallbackTests.m
+++ b/RZBluetoothTests/RZBCentralManagerCallbackTests.m
@@ -49,6 +49,45 @@ static NSString *const RZBTestString = @"StringValue";
     [self waitForQueueFlush];
 }
 
+- (void)performCentralStateErrorForState:(CBCentralManagerState)state
+{
+    __block NSError *readError = nil;
+    RZBPeripheral *peripheral = [self.centralManager peripheralForUUID:self.class.pUUID];
+    // Perform a read, and ensure that nothing occurs while state == Unknown.
+    [peripheral readCharacteristicUUID:self.class.cUUID
+                           serviceUUID:self.class.sUUID
+                            completion:^(CBCharacteristic *characteristic, NSError *error) {
+                                readError = error;
+                            }];
+    [self waitForQueueFlush];
+
+    RZBAssertCommandCount(1);
+    RZBAssertHasCommand(RZBReadCharacteristicCommand, self.class.cUUIDPath, NO);
+
+    // Turn the power off and ensure that an error is generated
+    // the proper CB method
+    [self.mockCentralManager fakeStateChange:state];
+    [self waitForQueueFlush];
+    XCTAssertNotNil(readError);
+    XCTAssert([readError.domain isEqualToString:RZBluetoothErrorDomain]);
+    XCTAssert(readError.code == state);
+}
+
+- (void)testCentralStateErrorPoweredOff
+{
+    [self performCentralStateErrorForState:CBCentralManagerStatePoweredOff];
+}
+
+- (void)testCentralStateErrorUnauthorized
+{
+    [self performCentralStateErrorForState:CBCentralManagerStateUnauthorized];
+}
+
+- (void)testCentralStateErrorUnsupported
+{
+    [self performCentralStateErrorForState:CBCentralManagerStateUnsupported];
+}
+
 - (void)testRead
 {
     RZBPeripheral *peripheral = [self.centralManager peripheralForUUID:self.class.pUUID];


### PR DESCRIPTION
Hey @dostrander -- this should resolve the error not triggering if the state change occurs after the command is submitted.