### PR TITLE
Fix Crash with clear characteristic

### DIFF
--- a/RZBluetooth/RZBPeripheral.m
+++ b/RZBluetooth/RZBPeripheral.m
@@ -157,7 +157,7 @@
     // If anything here is nil, there is no completion block, which is fine.
     CBService *service = [self.centralManager serviceForUUID:serviceUUID onPeripheral:self.corePeripheral];
     CBCharacteristic *characteristic = [service rzb_characteristicForUUID:characteristicUUID];
-    [self setNotifyBlock:nil forCharacteristicUUID:characteristic.UUID];
+    [self setNotifyBlock:nil forCharacteristicUUID:characteristicUUID];
 
     RZBNotifyCharacteristicCommand *cmd = [[RZBNotifyCharacteristicCommand alloc] initWithUUIDPath:path];
     cmd.notify = NO;


### PR DESCRIPTION
This should resolve #32 where a clear for a characteristic that had not been discovered would cause a crash.