### PR TITLE
Fix RZBMockPeripheral -[fakeCharacteristic:updateValue:error:] nullability

### DIFF
--- a/RZMockBluetooth/Mock/RZBMockPeripheral.h
+++ b/RZMockBluetooth/Mock/RZBMockPeripheral.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)fakeDiscoverCharacteristics:(NSArray<CBCharacteristic *> *)characteristics forService:(CBMutableService *)service error:(NSError *__nullable)error;
 - (void)fakeDiscoverCharacteristicsWithUUIDs:(NSArray<CBUUID *> *)characteristicUUIDs forService:(CBMutableService *)service error:(NSError *__nullable)error;
 
-- (void)fakeCharacteristic:(CBMutableCharacteristic *)characteristic updateValue:(NSData *)value error:(NSError *__nullable)error;
+- (void)fakeCharacteristic:(CBMutableCharacteristic *)characteristic updateValue:(NSData *__nullable)value error:(NSError *__nullable)error;
 - (void)fakeCharacteristic:(CBMutableCharacteristic *)characteristic writeResponseWithError:(NSError *__nullable)error;
 - (void)fakeCharacteristic:(CBMutableCharacteristic *)characteristic notify:(BOOL)notifyState error:(NSError *__nullable)error;
 


### PR DESCRIPTION
Simple fix for this method to allow testing of `nil` characteristic values. Makes sense, since the underlying `CBMutableCharacteristic.value` property is also nullable.

Although I have no idea if this condition is ever possible in reality, in Swift I have to unwrap the `Optional<Data>` when reading the value, so I'd like to be able to test those code paths.