### PR TITLE
Fix for issue #52

### DIFF
--- a/RZBluetoothTests/RZBSimulatedTests.m
+++ b/RZBluetoothTests/RZBSimulatedTests.m
@@ -260,7 +260,7 @@
     __block NSString *newStaticValue  = @"foobar";
     __block NSString *dynamicValue    = @"expected";
     
-    CBUUID *uuid = [CBUUID UUIDWithString:@"E2A05461"];
+    CBUUID *uuid = [CBUUID UUIDWithString:@"AC764575-B8D2-4DB0-9D04-D8A7F270CE8B"];
     CBMutableService *testService = [[CBMutableService alloc] initWithType:uuid primary:YES];
     
     CBUUID *staticUUID = [CBUUID UUIDWithString:@"18266046"];

--- a/RZBluetoothTests/RZBSimulatedTests.m
+++ b/RZBluetoothTests/RZBSimulatedTests.m
@@ -240,4 +240,111 @@
 
 }
 
+- (CBATTError)mockUpdateOnCharacteristicUUID:(CBUUID *)uuid withValue:(NSData *)value
+{
+    CBMutableCharacteristic* characteristic = [self.device characteristicForUUID:uuid];
+    if (characteristic != nil) {
+        if ([self.device.peripheralManager updateValue:value forCharacteristic:characteristic onSubscribedCentrals:nil]) {
+            return CBATTErrorSuccess;
+        }
+    }
+    return CBATTErrorRequestNotSupported;
+}
+
+- (void)testStaticCharacteristics
+{
+    __block int staticCallbackCount  = 0;
+    __block int dynamicCallbackCount = 0;
+    
+    NSString *staticValue = @"static";
+    __block NSString *newStaticValue  = @"foobar";
+    __block NSString *dynamicValue    = @"expected";
+    
+    CBUUID *uuid = [CBUUID UUIDWithString:@"E2A05461"];
+    CBMutableService *testService = [[CBMutableService alloc] initWithType:uuid primary:YES];
+    
+    CBUUID *staticUUID = [CBUUID UUIDWithString:@"18266046"];
+    CBMutableCharacteristic *staticChar = [[CBMutableCharacteristic alloc] initWithType:staticUUID
+                                                                             properties:CBCharacteristicPropertyRead
+                                                                                  value:[staticValue dataUsingEncoding:NSUTF8StringEncoding]
+                                                                            permissions:CBAttributePermissionsReadable];
+    CBUUID *dynamicUUID = [CBUUID UUIDWithString:@"35FF1332"];
+    CBMutableCharacteristic *dynamicChar = [[CBMutableCharacteristic alloc] initWithType:dynamicUUID
+                                                                              properties:CBCharacteristicPropertyRead
+                                                                                   value:nil
+                                                                             permissions:CBAttributePermissionsReadable];
+    testService.characteristics = @[staticChar, dynamicChar];
+    
+    [self.device addService:testService];
+    
+    __block typeof(self) welf = (id)self;
+    [self.device addReadCallbackForCharacteristicUUID:staticUUID handler:^CBATTError(CBATTRequest * _Nonnull request) {
+        staticCallbackCount++;
+        return [welf mockUpdateOnCharacteristicUUID:staticUUID withValue:[newStaticValue dataUsingEncoding:NSUTF8StringEncoding]];
+    }];
+    [self.device addReadCallbackForCharacteristicUUID:dynamicUUID handler:^CBATTError(CBATTRequest * _Nonnull request) {
+        dynamicCallbackCount++;
+        return [welf mockUpdateOnCharacteristicUUID:dynamicUUID withValue:[dynamicValue dataUsingEncoding:NSUTF8StringEncoding]];
+    }];
+    
+    // Configure the peripheral
+    RZBPeripheral *p = [self.centralManager peripheralForUUID:self.connection.identifier];
+    
+    // Read both static and dynamic characteristics
+    [p readCharacteristicUUID:staticUUID serviceUUID:testService.UUID completion:^(CBCharacteristic * _Nullable characteristic, NSError * _Nullable error) {
+        NSData *value = characteristic.value;
+        XCTAssertNotNil(value);
+        
+        NSString *string = [[NSString alloc] initWithData:value encoding:NSUTF8StringEncoding];
+        XCTAssertTrue([string isEqualToString:staticValue]);
+    }];
+    [p readCharacteristicUUID:dynamicUUID serviceUUID:testService.UUID completion:^(CBCharacteristic * _Nullable characteristic, NSError * _Nullable error) {
+        NSData *value = characteristic.value;
+        XCTAssertNotNil(value);
+        
+        NSString *string = [[NSString alloc] initWithData:value encoding:NSUTF8StringEncoding];
+        XCTAssertTrue([string isEqualToString:dynamicValue]);
+    }];
+    [self waitForQueueFlush];
+    
+    // Modify the dynamic value and try it again
+    dynamicValue   = @"updated";
+    [p readCharacteristicUUID:staticUUID serviceUUID:testService.UUID completion:^(CBCharacteristic * _Nullable characteristic, NSError * _Nullable error) {
+        NSData *value = characteristic.value;
+        XCTAssertNotNil(value);
+        
+        NSString *string = [[NSString alloc] initWithData:value encoding:NSUTF8StringEncoding];
+        XCTAssertTrue([string isEqualToString:staticValue]);
+    }];
+    [p readCharacteristicUUID:dynamicUUID serviceUUID:testService.UUID completion:^(CBCharacteristic * _Nullable characteristic, NSError * _Nullable error) {
+        NSData *value = characteristic.value;
+        XCTAssertNotNil(value);
+        
+        NSString *string = [[NSString alloc] initWithData:value encoding:NSUTF8StringEncoding];
+        XCTAssertTrue([string isEqualToString:dynamicValue]);
+    }];
+    [self waitForQueueFlush];
+    
+    // Remove the service and read callbacks and try it again
+    [self.device removeReadCallbackForCharacteristicUUID:staticUUID];
+    [self.device removeReadCallbackForCharacteristicUUID:dynamicUUID];
+    [self.device removeService:testService];
+
+    [p readCharacteristicUUID:staticUUID serviceUUID:testService.UUID completion:^(CBCharacteristic * _Nullable characteristic, NSError * _Nullable error) {
+        NSData *value = characteristic.value;
+        XCTAssertNil(value);
+        XCTAssertNotNil(error);
+    }];
+    [p readCharacteristicUUID:dynamicUUID serviceUUID:testService.UUID completion:^(CBCharacteristic * _Nullable characteristic, NSError * _Nullable error) {
+        NSData *value = characteristic.value;
+        XCTAssertNil(value);
+        XCTAssertNotNil(error);
+    }];
+    [self waitForQueueFlush];
+
+    XCTAssertEqual(staticCallbackCount,  0);
+    XCTAssertEqual(dynamicCallbackCount, 2);
+    
+}
+
 @end

--- a/RZMockBluetooth/Simulation/RZBSimulatedConnection+Private.h
+++ b/RZMockBluetooth/Simulation/RZBSimulatedConnection+Private.h
@@ -20,6 +20,17 @@
 @property (strong, nonatomic, readonly) NSMutableArray *writeRequests;
 @property (strong, nonatomic, readonly) NSMutableArray *subscribedCharacteristics;
 
+/**
+ Dictionary of dictionaries of static characteristic values
+ provided by the service when it is added to the peripheral.
+ Read handlers for static characteristics on simulated devices
+ will never be called.
+ 
+ Outer dictionary key is the service UUID.
+ Inner dictionary key is the characteristic UUID.
+ */
+@property (strong, nonatomic, readonly) NSMutableDictionary *staticCharacteristicValues;
+
 @property (weak, nonatomic, readonly) RZBSimulatedCentral *central;
 @property (strong, nonatomic) RZBMockPeripheral *peripheral;
 

--- a/RZMockBluetooth/Simulation/RZBSimulatedConnection.m
+++ b/RZMockBluetooth/Simulation/RZBSimulatedConnection.m
@@ -160,6 +160,9 @@
     CBUUID *outerKey = characteristic.service.UUID;
     CBUUID *innerKey = characteristic.UUID;
     NSMutableDictionary* staticValueDictionary = self.staticCharacteristicValues[outerKey];
+    if (staticValueDictionary == nil && value == nil) {
+        return;
+    }
     if (staticValueDictionary == nil) {
         staticValueDictionary = [NSMutableDictionary dictionary];
     }
@@ -169,7 +172,12 @@
     else {
         staticValueDictionary[innerKey] = value;
     }
-    self.staticCharacteristicValues[outerKey] = staticValueDictionary;
+    if (staticValueDictionary.count == 0) {
+        [self.staticCharacteristicValues removeObjectForKey:outerKey];
+    }
+    else {
+        self.staticCharacteristicValues[outerKey] = staticValueDictionary;
+    }
 }
 
 - (NSData * _Nullable)staticValueForCharacteristic:(CBCharacteristic *)characteristic
@@ -370,11 +378,8 @@
 
 - (void)mockPeripheralManager:(RZBMockPeripheralManager *)peripheralManager removeService:(CBMutableService *)service
 {
-    // Clear any static characteristic values associated with the removed service.
-    for (CBMutableCharacteristic *characteristic in service.characteristics) {
-        NSAssert([characteristic isKindOfClass:[CBMutableCharacteristic class]], @"");
-        [self setStaticValue:nil forCharacteristic:characteristic];
-    }
+    // Clear static characteristic values associated with the removed service.
+    [self.staticCharacteristicValues removeObjectForKey:service.UUID];
 }
 
 - (void)mockPeripheralManagerRemoveAllServices:(RZBMockPeripheralManager *)peripheralManager

--- a/RZMockBluetooth/Simulation/RZBSimulatedDevice.h
+++ b/RZMockBluetooth/Simulation/RZBSimulatedDevice.h
@@ -85,6 +85,11 @@ typedef void (^RZBPeripheralManagerStateBlock)(RZBPeripheralManagerState state);
 - (void)addService:(CBMutableService *)service;
 
 /**
+ * Remove a service from the device.
+ */
+- (void)removeService:(CBMutableService *)service;
+
+/**
  *  Block based API for adding read callback handlers for a characteristic with a specific UUID. Subclasses
  *  can also over-ride CBPeripheralManagerDelegate methods, as long as super is called.
  */
@@ -101,6 +106,24 @@ typedef void (^RZBPeripheralManagerStateBlock)(RZBPeripheralManagerState state);
  *  can also over-ride CBPeripheralManagerDelegate methods, as long as super is called.
  */
 - (void)addSubscribeCallbackForCharacteristicUUID:(CBUUID *)characteristicUUID handler:(RZBNotificationHandler)handler;
+
+/**
+ *  API for removing read callback handlers for a characteristic with a specific UUID. Subclasses
+ *  can also over-ride CBPeripheralManagerDelegate methods, as long as super is called.
+ */
+- (void)removeReadCallbackForCharacteristicUUID:(CBUUID *)characteristicUUID;
+
+/**
+ *  API for removing write callback handlers for a characteristic with a specific UUID. Subclasses
+ *  can also over-ride CBPeripheralManagerDelegate methods, as long as super is called.
+ */
+- (void)removeWriteCallbackForCharacteristicUUID:(CBUUID *)characteristicUUID;
+
+/**
+ *  API for removing subscribe callback handlers for a characteristic with a specific UUID. Subclasses
+ *  can also over-ride CBPeripheralManagerDelegate methods, as long as super is called.
+ */
+- (void)removeSubscribeCallbackForCharacteristicUUID:(CBUUID *)characteristicUUID;
 
 /**
  *  Add a RZBBluetoothRepresentable object to the simulated device.

--- a/RZMockBluetooth/Simulation/RZBSimulatedDevice.m
+++ b/RZMockBluetooth/Simulation/RZBSimulatedDevice.m
@@ -115,6 +115,16 @@
     }];
 }
 
+- (void)removeService:(CBMutableService *)service
+{
+    @synchronized (self.services) {
+        [[self mutableArrayValueForKey:@"services"] removeObject:service];
+    }
+    [self performPeripheralAction:^{
+        [self.peripheralManager removeService:service];
+    }];
+}
+
 - (void)addBluetoothRepresentable:(id<RZBBluetoothRepresentable>)bluetoothRepresentable isPrimary:(BOOL)isPrimary
 {
     NSParameterAssert(bluetoothRepresentable);
@@ -146,6 +156,30 @@
     NSParameterAssert(handler);
     @synchronized (self.subscribeHandlers) {
         self.subscribeHandlers[characteristicUUID] = [handler copy];
+    }
+}
+
+- (void)removeReadCallbackForCharacteristicUUID:(CBUUID *)characteristicUUID
+{
+    NSParameterAssert(characteristicUUID);
+    @synchronized (self.readHandlers) {
+        [self.readHandlers removeObjectForKey:characteristicUUID];
+    }
+}
+
+- (void)removeWriteCallbackForCharacteristicUUID:(CBUUID *)characteristicUUID
+{
+    NSParameterAssert(characteristicUUID);
+    @synchronized (self.writeHandlers) {
+        [self.writeHandlers removeObjectForKey:characteristicUUID];
+    }
+}
+
+- (void)removeSubscribeCallbackForCharacteristicUUID:(CBUUID *)characteristicUUID
+{
+    NSParameterAssert(characteristicUUID);
+    @synchronized (self.subscribeHandlers) {
+        [self.subscribeHandlers removeObjectForKey:characteristicUUID];
     }
 }
 


### PR DESCRIPTION
Instead of tracking dynamic characteristic UUIDs, as you suggested, I decided to track static characteristic values. It seems to me that static characteristic values are less common, so this code has the least impact.

I also added methods to `RZBSimulatedDevice` to remove services and handlers, so I could unit test the code that removes static characteristic values.