### PR TITLE
@synchronize access to RZBMockPeripheralManager.services.

### DIFF
--- a/RZMockBluetooth/Mock/RZBMockPeripheralManager.m
+++ b/RZMockBluetooth/Mock/RZBMockPeripheralManager.m
@@ -47,19 +47,25 @@
 
 - (void)addService:(CBMutableService *)service
 {
-    [self.services addObject:service];
+    @synchronized (self.services) {
+        [self.services addObject:service];
+    }
     [self.mockDelegate mockPeripheralManager:self addService:service];
 }
 
 - (void)removeService:(CBMutableService *)service
 {
-    [self.services removeObject:service];
+    @synchronized (self.services) {
+        [self.services removeObject:service];
+    }
     [self.mockDelegate mockPeripheralManager:self removeService:service];
 }
 
 - (void)removeAllServices
 {
-    [self.services removeAllObjects];
+    @synchronized (self.services) {
+        [self.services removeAllObjects];
+    }
     [self.mockDelegate mockPeripheralManagerRemoveAllServices:self];
 }
 


### PR DESCRIPTION
I currently have 651 unit tests in my project that use the RZBMockBluetooth classes to simulate connections to our devices, with 93% code coverage of our core classes (and 77% coverage of RZBluetooth). I found that running our tests would succeed completely about 90% of the time. When they would fail, the failure was usually due to one of 2 reasons:
1. A double-dealloc crash would occur in `RZBMockPeripheralManager -addService:`.
2. The unit test would fail because of a random `RZBluetoothDiscoverServiceError` (ie. there was no matching `CBService` object in the mock device, even though we call `-addService:` in our test case `setUp()` method).

I noticed that, although `RZBSimulatedDevice -addService:` used `@synchronized (self.devices)`, `RZBMockPeripheralManager` did not. So, I tried patching it to do so.
 
I set up a command line script to run our unit test suite 100 times, both with and without this patch.
- Without patch: 160 failures out of 65100 tests
- With patch: 0 failures out of 65100 tests

Does this change make sense?