### PR TITLE
Do not setNotify: NO if disconnected

### DIFF
--- a/RZBluetooth/Command/RZBCommand.h
+++ b/RZBluetooth/Command/RZBCommand.h
@@ -36,6 +36,7 @@ typedef void(^RZBCallbackBlock)(id object, NSError *error);
 @property (assign, nonatomic) NSTimeInterval expiresAt;
 @property (assign, nonatomic, readonly) BOOL isUserInteraction;
 @property (assign, nonatomic, readonly) BOOL isExpired;
+@property (assign, nonatomic, readonly) BOOL canCauseReconnection;
 
 - (BOOL)executeCommandWithContext:(id)context error:(inout NSError **)error;
 

--- a/RZBluetooth/Command/RZBCommand.m
+++ b/RZBluetooth/Command/RZBCommand.m
@@ -70,6 +70,15 @@
     return self;
 }
 
+-(BOOL)canCauseReconnection {
+    // check if command is of type notify
+    if ([self isKindOfClass:[RZBNotifyCharacteristicCommand class]]) {
+        RZBNotifyCharacteristicCommand *command = (RZBNotifyCharacteristicCommand *)self;
+        return command.notify;
+    }
+    return YES;
+}
+
 - (BOOL)isUserInteraction
 {
     return self.expiresAt > 0;


### PR DESCRIPTION
When you call clearNotifyBlock on a disconnected peripheral, it will no
longer cause a reconnection