### PR TITLE
Add retrievePeripheralsWithIdentifiers method

### DIFF
--- a/RZBluetooth/RZBCentralManager.h
+++ b/RZBluetooth/RZBCentralManager.h
@@ -92,6 +92,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<RZBPeripheral *> *)retrieveConnectedPeripheralsWithServices:(NSArray<CBUUID *> *)serviceUUIDs;
 
 /**
+ * Retrieve list of known peripherals by their identifiers.
+ */
+- (NSArray<RZBPeripheral *> *)retrievePeripheralsWithIdentifiers:(NSArray<NSUUID *> *)identifiers;
+
+/**
  * This is the CoreBluetooth central manager that backs this central manager.
  * This is exposed for informational and testing purposes only. Directly invoking
  * methods on this object may cause un-expected behavior.

--- a/RZBluetooth/RZBCentralManager.m
+++ b/RZBluetooth/RZBCentralManager.m
@@ -100,12 +100,14 @@
 
 - (NSArray<RZBPeripheral *> *)retrieveConnectedPeripheralsWithServices:(NSArray<CBUUID *> *)serviceUUIDs
 {
-    NSMutableArray<RZBPeripheral *> *result = [NSMutableArray array];
     NSArray<CBPeripheral *> *connectedPeripherals = [self.coreCentralManager retrieveConnectedPeripheralsWithServices:serviceUUIDs];
-    for (CBPeripheral *p in connectedPeripherals) {
-        [result addObject:[self peripheralForCorePeripheral:p]];
-    }
-    return result;
+    return [self peripheralsForCorePeripherals:connectedPeripherals];
+}
+
+- (NSArray<RZBPeripheral *> *)retrievePeripheralsWithIdentifiers:(NSArray<NSUUID *> *)identifiers
+{
+    NSArray<CBPeripheral *> *peripherals = [self.coreCentralManager retrievePeripheralsWithIdentifiers:identifiers];
+    return [self peripheralsForCorePeripherals:peripherals];
 }
 
 #pragma mark - Lookup Helpers
@@ -117,6 +119,14 @@
     CBPeripheral *peripheral = [peripherals lastObject];
     peripheral.delegate = self;
     return peripheral;
+}
+
+- (NSArray<RZBPeripheral* > *)peripheralsForCorePeripherals:(NSArray<CBPeripheral*>*) peripherals {
+    NSMutableArray<RZBPeripheral *> *result = [NSMutableArray array];
+    for (CBPeripheral *p in peripherals) {
+        [result addObject:[self peripheralForCorePeripheral:p]];
+    }
+    return result;
 }
 
 - (RZBPeripheral *)peripheralForCorePeripheral:(CBPeripheral *)corePeripheral

--- a/RZBluetoothTests/RZBCentralManagerCallbackTests.m
+++ b/RZBluetoothTests/RZBCentralManagerCallbackTests.m
@@ -563,4 +563,14 @@ static NSString *const RZBTestString = @"StringValue";
     XCTAssertEqual(connectedPeripherals.count, 0);
 }
 
+- (void)testRetrievePeripherals
+{
+    NSArray<RZBPeripheral*>* peripherals = [self.centralManager retrievePeripheralsWithIdentifiers:@[NSUUID.pUUID]];
+    XCTAssertNotNil(peripherals);
+    XCTAssertEqual(peripherals.count, 1);
+    XCTAssertEqual(peripherals.firstObject.identifier, NSUUID.pUUID);
+    
+    XCTAssertEqualObjects([self.invocationLog argumentAtIndex:0 forSelector:@selector(retrievePeripheralsWithIdentifiers:)], @[NSUUID.pUUID]);
+}
+
 @end


### PR DESCRIPTION
Very similar to the existing 
`retrieveConnectedPeripheralsWithServices:(NSArray<CBUUID *> *)serviceUUIDs`.

This method already exists for `CBCentralManager` and this is a simple wrapper to it.