### PR TITLE
Only support bluetooth background mode if target's backround mode is enabled.

### DIFF
--- a/RZBluetooth/RZBCentralManager.h
+++ b/RZBluetooth/RZBCentralManager.h
@@ -61,6 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * This block will be triggered when restored with an array of RZBPeripheral objects.
  * You can also use NSNotificationCenter to watch for notifications named RZBCentralManagerRestorePeripheralNotification.
+ *
+ * To support state restoriation, you need to enable the 'Uses Bluetooth LE accessories' background mode.
  */
 @property (nonatomic, copy) RZBRestorationBlock restorationHandler;
 


### PR DESCRIPTION
Fix for issue #35

By responding to the `centralManager:willRestoreState:` selector only if target's background mode is enabled, `RZBluetooth` can be used without following warning:

`API MISUSE: has no restore identifier but the delegate implements the centralManager:willRestoreState: method. Restoring will not be supported`