### PR TITLE
Fix a 9.x crash

### DIFF
--- a/RZMockBluetooth/Simulation/RZBSimulatedCallback.m
+++ b/RZMockBluetooth/Simulation/RZBSimulatedCallback.m
@@ -113,6 +113,11 @@ static NSTimeInterval __defaultDelay = 0;
 {
     @synchronized(self) {
         for (dispatch_source_t timer in self.timers) {
+            // In Xcode 9+, you can not cancel an inactive / suspended timer.
+            // So if the callback is paused, resume it before canceling
+            if (self.paused) {
+                dispatch_resume(timer);
+            }
             dispatch_cancel(timer);
         }
         [self.timers removeAllObjects];


### PR DESCRIPTION
Hey @drdaz / @cpatterson-lilly , I found a fix for the issue. It appears that in Xcode 9.0 + you can not deallocate an inactive or suspended timer. 😱 

Thanks for your help tracking it down!