### PR TITLE
Fix compiler warnings

### DIFF
--- a/RZBluetooth.podspec
+++ b/RZBluetooth.podspec
@@ -16,7 +16,7 @@ RZBluetooth is a Core Bluetooth helper with 3 primary goals:
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Brian King" => "brianaking@gmail.com" }
   s.osx.deployment_target = "10.10"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "10.0"
   s.watchos.deployment_target = "4.0"
   s.source       = { :git => "https://github.com/Raizlabs/RZBluetooth.git", :tag => s.version }
   s.requires_arc = true

--- a/RZBluetooth.podspec
+++ b/RZBluetooth.podspec
@@ -16,7 +16,7 @@ RZBluetooth is a Core Bluetooth helper with 3 primary goals:
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Brian King" => "brianaking@gmail.com" }
   s.osx.deployment_target = "10.10"
-  s.ios.deployment_target = "10.0"
+  s.ios.deployment_target = "8.0"
   s.watchos.deployment_target = "4.0"
   s.source       = { :git => "https://github.com/Raizlabs/RZBluetooth.git", :tag => s.version }
   s.requires_arc = true

--- a/RZBluetooth/Profiles/RZBDeviceInfo.m
+++ b/RZBluetooth/Profiles/RZBDeviceInfo.m
@@ -47,7 +47,7 @@ const int    kOUIDShift             = 40;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"%06X-%010llX", self.ouid, self.manufacturerId];
+    return [NSString stringWithFormat:@"%06X-%010llX", (unsigned int)self.ouid, self.manufacturerId];
 }
 
 - (NSData *)characteristicValue
@@ -64,7 +64,7 @@ const int    kOUIDShift             = 40;
 + (id)valueForKey:(NSString *)key fromData:(NSData *)data
 {
     NSAssert([key isEqualToString:@"pnpId"], @"Unexpected key for RZBPnPId: %@", key);
-
+    
     RZBPnPId *pnpId = [[RZBPnPId alloc] init];
     RZBVendorIdSource rawVendorIdSource = RZBVendorIdSourceReserved;
     UInt16 rawId = 0;

--- a/RZBluetooth/Profiles/RZBDeviceInfo.m
+++ b/RZBluetooth/Profiles/RZBDeviceInfo.m
@@ -64,7 +64,7 @@ const int    kOUIDShift             = 40;
 + (id)valueForKey:(NSString *)key fromData:(NSData *)data
 {
     NSAssert([key isEqualToString:@"pnpId"], @"Unexpected key for RZBPnPId: %@", key);
-    
+
     RZBPnPId *pnpId = [[RZBPnPId alloc] init];
     RZBVendorIdSource rawVendorIdSource = RZBVendorIdSourceReserved;
     UInt16 rawId = 0;


### PR DESCRIPTION
Our team sometimes has a compiler warning show up in Xcode 9.4.1. This fixes it. 

This PR is the same as #89 but without the changes to the podspec.