### PR TITLE
Core Bluetooth options

### DIFF
--- a/RZBluetooth/RZBCentralManager.h
+++ b/RZBluetooth/RZBCentralManager.h
@@ -47,6 +47,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithIdentifier:(NSString *)identifier peripheralClass:(Class)peripheralClass queue:(dispatch_queue_t __nullable)queue;
 
 /**
+ * Create a new central manager
+ *
+ * @param identifier the restore identifier.
+ * @param peripheralClass the subclass of RZBPeripheral to use
+ * @param queue the dispatch queue for the central to use. The main queue will be used if queue is nil.
+ *              It is important that the dispatch queue be a serial queue
+ * @param options An optional dictionary containing initialization options for a core bluetooth central manager. For available options, see Core Bluetooth Central Manager Initialization Options.
+ */
+- (instancetype)initWithIdentifier:(NSString *)identifier peripheralClass:(Class)peripheralClass queue:(dispatch_queue_t __nullable)queue options:(nullable NSDictionary<NSString *,id> *)options;
+
+/**
  * Expose the backing CBManagerState. See RZBluetoothErrorForState to generate an
  * error object representing the non-functioning terminal states.
  */

--- a/RZBluetooth/RZBCentralManager.m
+++ b/RZBluetooth/RZBCentralManager.m
@@ -64,14 +64,23 @@
 
 - (instancetype)initWithIdentifier:(NSString *)identifier peripheralClass:(Class)peripheralClass queue:(dispatch_queue_t __nullable)queue;
 {
+    return [self initWithIdentifier:identifier peripheralClass:peripheralClass queue:queue options:nil];
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier peripheralClass:(Class)peripheralClass queue:(dispatch_queue_t __nullable)queue options:(NSDictionary<NSString *,id> *)options
+{
     NSParameterAssert(identifier);
     self = [super init];
     if (self) {
         _peripheralClass = peripheralClass ?: [RZBPeripheral class];
-        NSDictionary *options = [self.class optionsForIdentifier:identifier];
+        
+        NSMutableDictionary *mergedOptions = [[self.class optionsForIdentifier:identifier] mutableCopy];
+        if (options != nil) {
+            [mergedOptions addEntriesFromDictionary:options];
+        }
         _coreCentralManager = [[CBCentralManager alloc] initWithDelegate:self
                                                                    queue:queue
-                                                                 options:options];
+                                                                 options:mergedOptions];
         _dispatch = [[RZBCommandDispatch alloc] initWithQueue:queue context:self];
         _peripheralsByUUID = [NSMutableDictionary dictionary];
     }


### PR DESCRIPTION
Add a new designated initializier that optionally takes core bluetooth central manager options and passes them to the core central manager. For example, this allows to use `CBCentralManagerOptionShowPowerAlertKey`, an alert that informs the user about disabled bluetooth when a central manager is instantiated.