### PR TITLE
Shortened the poll time in waitForQueueFlush

### DIFF
--- a/RZBluetoothTests/RZBSimulatedTestCase.m
+++ b/RZBluetoothTests/RZBSimulatedTestCase.m
@@ -31,7 +31,7 @@
     NSDate *endDate = [NSDate dateWithTimeIntervalSinceNow:10.0];
     // Wait for all of the connections to go idle
     while (!(self.central.idle && self.centralManager.dispatch.dispatchCounter == 0) && [endDate timeIntervalSinceNow] > 0) {
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.00001]];
     }
     XCTAssertTrue([endDate timeIntervalSinceNow] > 0);
 }


### PR DESCRIPTION
This one weird trick cut our test suite execution time in half.