### PR TITLE
update podspec to 2.0.1 to incorporate bug fixes

### DIFF
--- a/RZBluetooth.podspec
+++ b/RZBluetooth.podspec
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 Pod::Spec.new do |s|
   s.name         = "RZBluetooth"
-  s.version      = "2.0.0"
+  s.version      = "2.0.1"
   s.summary      = "A Core Bluetooth helper library to simplify the development and testing of Core Bluetooth applications."
 
   s.description  = <<-DESC


### PR DESCRIPTION
Podspec repo is not up-to-date with RZBluetooth master and needs an update. 

Non-released dependencies can only be set in the Podfile, not the Podspec. This was causing issues for consumers of our library.